### PR TITLE
Add virtualenv support

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ This is a step by step set of instructions you can take to get up and running wi
 2. Run the following CLI command to get the default configurations setup in airflow.cfg
  
         scheduler_failover_controller init
+
+##### PS: Virtualenv support
+You can use the scheduler_failover_controller on a virtual environment too. To do so, you need to specify the activation path of your virtual environment:
+
+        scheduler_failover_controller -venv PATH_TO_VIRTUALENV/bin/activate init
+
         
 3. Update the default configurations that were added to the bottom of the airflow.cfg file under the [scheduler_failover] section
 

--- a/scheduler_failover_controller/bin/cli.py
+++ b/scheduler_failover_controller/bin/cli.py
@@ -40,7 +40,11 @@ def version(args):
 
 
 def init(args):
-    configuration.add_default_scheduler_failover_configs_to_airflow_configs()
+    if(args.venv is not None):
+        venv_command = "source " + args.venv
+    else:
+        venv_command = ""
+    configuration.add_default_scheduler_failover_configs_to_airflow_configs(venv_command)
     print "Finished Initializing Configurations to allow Scheduler Failover Controller to run. Please update the airflow.cfg with your desired configurations."
 
 
@@ -99,7 +103,9 @@ def get_parser():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(help='sub-command help', dest='subcommand')
     subparsers.required = True
-
+    
+    parser.add_argument('-venv', help='Specify virtualenv activation path')
+    
     ht = "Prints out the version of the Scheduler Failover Controller"
     parser_logs = subparsers.add_parser('version', help=ht)
     parser_logs.set_defaults(func=version)

--- a/scheduler_failover_controller/configuration.py
+++ b/scheduler_failover_controller/configuration.py
@@ -35,10 +35,10 @@ metadata_service_zookeeper_nodes = localhost:2181
 poll_frequency = """ + str(DEFAULT_POLL_FREQUENCY) + """
 
 # Command to use when trying to start a Scheduler instance on a node
-airflow_scheduler_start_command = nohup airflow scheduler >> ~/airflow/logs/scheduler.logs &
+airflow_scheduler_start_command = export AIRFLOW_HOME=""" + str(DEFAULT_AIRFLOW_HOME_DIR) + """;{};nohup airflow scheduler >> ~/airflow/logs/scheduler.logs &
 
 # Command to use when trying to stop a Scheduler instance on a node
-airflow_scheduler_stop_command = for pid in `ps -ef | grep "airflow scheduler" | awk '{print $2}'` \; do kill -9 $pid \; done
+airflow_scheduler_stop_command = for pid in `ps -ef | grep "airflow scheduler" | awk '{{print $2}}'` \; do kill -9 $pid \; done
 
 # Logging Level. Choices include:
 # NOTSET, DEBUG, INFO, WARN, ERROR, CRITICAL
@@ -178,12 +178,12 @@ class Configuration:
     def get_alert_email_subject(self):
         return self.get_scheduler_failover_config("ALERT_EMAIL_SUBJECT", DEFAULT_ALERT_EMAIL_SUBJECT)
 
-    def add_default_scheduler_failover_configs_to_airflow_configs(self):
+    def add_default_scheduler_failover_configs_to_airflow_configs(self, venv_command):
         with open(self.airflow_config_file_path, 'r') as airflow_config_file:
             if "[scheduler_failover]" not in airflow_config_file.read():
                 print "Adding Scheduler Failover configs to Airflow config file..."
                 with open(self.airflow_config_file_path, "a") as airflow_config_file_to_append:
-                    airflow_config_file_to_append.write(DEFAULT_SCHEDULER_FAILOVER_CONTROLLER_CONFIGS)
+                    airflow_config_file_to_append.write(DEFAULT_SCHEDULER_FAILOVER_CONTROLLER_CONFIGS.format(venv_command))
                     print "Finished adding Scheduler Failover configs to Airflow config file."
             else:
                 print "[scheduler_failover] section already exists. Skipping adding Scheduler Failover configs."


### PR DESCRIPTION
Given that in a lot of cases, people will be using Airflow on virtualenvs. I added the possibility to run the scheduler failover controller on a python virtual environment.

Motivation: 
I wanted to use the scheduler failover controller to provide Airflow scheduler HA on a Hortonworks Data Platform cluster. But given the fact that I can't install it using the HDP's native python installation, I had to create a virtualenv for that. That's when I realized the failover controller won't be able to start schedulers because it would then have to activate the virtualenv each time it uses ssh (in order to recognize airflow commands). So I tweaked the code a little in order to be able to use ASFC on virtual environments. 