### PR TITLE
Ignore grep command self

### DIFF
--- a/scheduler_failover_controller/failover/failover_controller.py
+++ b/scheduler_failover_controller/failover/failover_controller.py
@@ -143,9 +143,9 @@ class FailoverController:
         self.logger.info("Starting to Check if Scheduler on host '" + str(host) + "' is running...")
 
         process_check_command = "ps -eaf"
-        grep_command = "grep 'airflow scheduler'"
+        grep_command = "grep 'airflow scheduler' | grep -v grep"
         grep_command_no_quotes = grep_command.replace("'", "")
-        full_status_check_command = process_check_command + " | " + grep_command  # ps -eaf | grep 'airflow scheduler'
+        full_status_check_command = process_check_command + " | " + grep_command  # ps -eaf | grep 'airflow scheduler' | grep -v grep
         is_running = False
         is_successful, output = self.command_runner.run_command(host, full_status_check_command)
         self.LATEST_FAILED_STATUS_MESSAGE = output


### PR DESCRIPTION
Some OS like CentOS will return grep command
when run `ps -eaf | grep 'airflow scheduler'`and
this situation functtion is_scheduler_runningdon't work