### PR TITLE
Allow environments variable overrides

### DIFF
--- a/scheduler_failover_controller/configuration.py
+++ b/scheduler_failover_controller/configuration.py
@@ -2,10 +2,15 @@ import os
 import socket
 import sys
 import logging
+import subprocess
+import shlex
 from six.moves import configparser
 
+
 def get_airflow_home_dir():
-    return os.environ['AIRFLOW_HOME'] if "AIRFLOW_HOME" in os.environ else os.path.expanduser("~/airflow")
+    return os.path.normpath(
+        os.environ['AIRFLOW_HOME'] if "AIRFLOW_HOME" in os.environ else os.path.expanduser("~/airflow"))
+
 
 DEFAULT_AIRFLOW_HOME_DIR = get_airflow_home_dir()
 DEFAULT_METADATA_SERVICE_TYPE = "SQLMetadataService"
@@ -68,22 +73,138 @@ alert_email_subject = """ + str(DEFAULT_ALERT_EMAIL_SUBJECT) + """
 """
 
 
+def run_command(command):
+    """
+    Runs command and returns stdout
+    """
+    process = subprocess.Popen(
+        shlex.split(command),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        close_fds=True)
+    output, stderr = [stream.decode(sys.getdefaultencoding(), 'ignore')
+                      for stream in process.communicate()]
+
+    if process.returncode != 0:
+        raise Exception(
+            "Cannot execute {}. Error code is: {}. Output: {}, Stderr: {}"
+                .format(command, process.returncode, output, stderr)
+        )
+
+    return output
+
+
+def expand_env_var(env_var):
+    """
+    Expands (potentially nested) env vars by repeatedly applying
+    `expandvars` and `expanduser` until interpolation stops having
+    any effect.
+    """
+    if not env_var:
+        return env_var
+    while True:
+        interpolated = os.path.expanduser(os.path.expandvars(str(env_var)))
+        if interpolated == env_var:
+            return interpolated
+        else:
+            env_var = interpolated
+
+
 class Configuration:
+    as_command_stdout = {
+        ('core', 'sql_alchemy_conn'),
+        ('core', 'fernet_key'),
+        ('celery', 'broker_url'),
+        ('celery', 'result_backend'),
+        ('atlas', 'password'),
+        ('smtp', 'smtp_password'),
+        ('ldap', 'bind_password'),
+        ('kubernetes', 'git_password'),
+    }
 
     def __init__(self, airflow_home_dir=None, airflow_config_file_path=None):
         if airflow_home_dir is None:
             airflow_home_dir = DEFAULT_AIRFLOW_HOME_DIR
         if airflow_config_file_path is None:
-            airflow_config_file_path = airflow_home_dir + "/airflow.cfg"
+            airflow_config_file_path = os.path.normpath(airflow_home_dir + "/airflow.cfg")
         self.airflow_home_dir = airflow_home_dir
         self.airflow_config_file_path = airflow_config_file_path
 
         if not os.path.isfile(airflow_config_file_path):
-            print ("Cannot find Airflow Configuration file at '" + str(airflow_config_file_path) + "'!!!")
+            print("Cannot find Airflow Configuration file at '" + str(airflow_config_file_path) + "'!!!")
             sys.exit(1)
 
         self.conf = configparser.RawConfigParser()
         self.conf.read(airflow_config_file_path)
+        self.override_conf_from_env_vars()
+
+    @staticmethod
+    def _env_var_name(section, key):
+        return 'AIRFLOW__{S}__{K}'.format(S=section.upper(), K=key.upper())
+
+    def _get_env_var_option(self, section, key):
+        # must have format AIRFLOW__{SECTION}__{KEY} (note double underscore)
+        env_var = self._env_var_name(section, key)
+        if env_var in os.environ:
+            return expand_env_var(os.environ[env_var])
+        # alternatively AIRFLOW__{SECTION}__{KEY}_CMD (for a command)
+        env_var_cmd = env_var + '_CMD'
+        if env_var_cmd in os.environ:
+            # if this is a valid command key...
+            if (section, key) in self.as_command_stdout:
+                return run_command(os.environ[env_var_cmd])
+
+    def override_conf_from_env_vars(self, display_source=False, display_sensitive=False, raw=False):
+        # # Original Code from https://github.com/apache/airflow/blob/master/airflow/configuration.py
+        # # Ported over from there, to allow environments variable overrides for all sections and section keys & values
+        #
+        # # This part of the original code is deemed unnecessary
+        # # for the original, it loads up the config file, but for us, self.conf has already loaded the airflow.cfg
+        # # since the self.init loads the airflow.cfg first, then runs this function to override
+        # # ////////////////////////////////////////////////////
+        # cfg: Dict[str, Dict[str, str]] = {}
+        # configs = [
+        #     ('airflow.cfg', self.conf),
+        # ]
+        #
+        # for (source_name, config) in configs:
+        #     for section in config.sections():
+        #         sect = cfg.setdefault(section, OrderedDict())
+        #         for (k, val) in config.items(section=section, raw=raw):
+        #             if display_source:
+        #                 val = (val, source_name)
+        #             sect[k] = val
+        # # ////////////////////////////////////////////////////
+
+        for ev in [ev for ev in os.environ if ev.startswith('AIRFLOW__')]:
+            try:
+                _, section, key = ev.split('__', 2)
+                opt = self._get_env_var_option(section, key)
+            except ValueError:
+                continue
+            # if not display_sensitive and ev != 'AIRFLOW__CORE__UNIT_TEST_MODE':
+            #     opt = '< hidden >'
+            if raw:
+                opt = opt.replace('%', '%%')
+            if display_source:
+                opt = (opt, 'env var')
+
+            section = section.lower()
+            # if we lower key for kubernetes_environment_variables section,
+            # then we won't be able to set any Airflow environment
+            # variables. Airflow only parse environment variables starts
+            # with AIRFLOW_. Therefore, we need to make it a special case.
+            if section != 'kubernetes_environment_variables':
+                key = key.lower()
+
+            # # PRE REQUISITE TO RUN THE COMMENTED FOR LOOP AT THE START OF THIS FUNCTION cfg.setdefault(section,
+            # OrderedDict()).update({key: opt})
+            # self.conf.update(cfg)
+            # # This is how to replace the entire config with
+            # # the merged airflow.cfg and env configs, but since we are iterating over each section+key, found in env,
+            # # we can replace only that for every new override
+
+            self.conf.setdefault(section, self.conf[section]).update({key: opt})
 
     @staticmethod
     def get_current_host():
@@ -163,7 +284,8 @@ class Configuration:
         return self.get_smtp_config("SMTP_MAIL_FROM")
 
     def get_retry_count_before_alerting(self):
-        return int(self.get_scheduler_failover_config("RETRY_COUNT_BEFORE_ALERTING", DEFAULT_RETRY_COUNT_BEFORE_ALERTING))
+        return int(
+            self.get_scheduler_failover_config("RETRY_COUNT_BEFORE_ALERTING", DEFAULT_RETRY_COUNT_BEFORE_ALERTING))
 
     def get_logs_rotate_when(self):
         return self.get_scheduler_failover_config("LOGS_ROTATE_WHEN", DEFAULT_LOGS_ROTATE_WHEN)
@@ -182,7 +304,8 @@ class Configuration:
             if "[scheduler_failover]" not in airflow_config_file.read():
                 print("Adding Scheduler Failover configs to Airflow config file...")
                 with open(self.airflow_config_file_path, "a") as airflow_config_file_to_append:
-                    airflow_config_file_to_append.write(DEFAULT_SCHEDULER_FAILOVER_CONTROLLER_CONFIGS.format(venv_command))
-                    print( "Finished adding Scheduler Failover configs to Airflow config file.")
+                    airflow_config_file_to_append.write(
+                        DEFAULT_SCHEDULER_FAILOVER_CONTROLLER_CONFIGS.format(venv_command))
+                    print("Finished adding Scheduler Failover configs to Airflow config file.")
             else:
                 print("[scheduler_failover] section already exists. Skipping adding Scheduler Failover configs.")


### PR DESCRIPTION
+ Copies over several functions from Airflow code, necessary to support environment variable overrides of defaults either under 'airflow.cfg', or 'airflow-scheduler-failover-controller' specific hard-coded defaults (present in this file)

Example Issue: Currently if an Airflow deployer, sets the environment variable:
AIRFLOW__CORE__SQL_ALCHEMY_CONN, Airflow would respect that config, and use that for Database connection, however, setting the same variable for 'airflow-scheduler-failover-controller', it it would be completely ignored, unless this PR has something to say about that.. :)

Miscellaneous changes:
 + Pycharm default file reformat
 + Paths are normalized though os.path.normpath (to support windows? maybe, to support running configuration.py on windows for sure)