### PR TITLE
[FIX] wait before checking scheduler is running on standby node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,3 +43,7 @@ Includes base functionality to control and check if the Scheduler is running. Su
 * Exit code fix when SSHing onto another node
 * Increase default polling frequency from 10 to 60 seconds
 * Add support for conifguring SCHEDULER_RESTART_SLEEP_TIME (default: 35 seconds)
+
+### [v1.0.9](https://github.com/teamclairvoyant/airflow-scheduler-failover-controller/tree/v1.0.9)
+
+* Wait before checking scheduler has started on the standby node

--- a/scheduler_failover_controller/failover/failover_controller.py
+++ b/scheduler_failover_controller/failover/failover_controller.py
@@ -103,6 +103,7 @@ class FailoverController:
                         for standby_node in self.get_standby_nodes(active_scheduler_node):
                             self.logger.warning("Trying to startup Scheduler on STANDBY node '" + str(standby_node) + "'")
                             self.startup_scheduler(standby_node)
+                            time.sleep(self.SCHEDULER_RESTART_SLEEP_TIME)
                             if self.is_scheduler_running(standby_node):
                                 is_successful = True
                                 active_scheduler_node = standby_node

--- a/scheduler_failover_controller/failover/failover_controller.py
+++ b/scheduler_failover_controller/failover/failover_controller.py
@@ -94,8 +94,7 @@ class FailoverController:
                 if not self.is_scheduler_running(active_scheduler_node):
                     self.logger.warning("Scheduler is not running on Active Scheduler Node '" + str(active_scheduler_node) + "'")
                     self.startup_scheduler(active_scheduler_node)
-                    self.logger.info("Pausing for " + str(self.SCHEDULER_RESTART_SLEEP_TIME) + " seconds to allow the Scheduler to Start")
-                    time.sleep(self.SCHEDULER_RESTART_SLEEP_TIME)
+
                     if not self.is_scheduler_running(active_scheduler_node):
                         self.logger.warning("Failed to restart Scheduler on Active Scheduler Node '" +str(active_scheduler_node) + "'")
                         self.logger.warning("Starting to search for a new Active Scheduler Node")
@@ -103,7 +102,6 @@ class FailoverController:
                         for standby_node in self.get_standby_nodes(active_scheduler_node):
                             self.logger.warning("Trying to startup Scheduler on STANDBY node '" + str(standby_node) + "'")
                             self.startup_scheduler(standby_node)
-                            time.sleep(self.SCHEDULER_RESTART_SLEEP_TIME)
                             if self.is_scheduler_running(standby_node):
                                 is_successful = True
                                 active_scheduler_node = standby_node
@@ -146,6 +144,8 @@ class FailoverController:
         self.logger.info("Starting Scheduler on host '" + str(host) + "'...")
         is_successful, output = self.command_runner.run_command(host, self.airflow_scheduler_start_command)
         self.LATEST_FAILED_START_MESSAGE = output
+        self.logger.info("Pausing for " + str(self.SCHEDULER_RESTART_SLEEP_TIME) + " seconds to allow the Scheduler to Start")
+        time.sleep(self.SCHEDULER_RESTART_SLEEP_TIME)
         self.logger.info("Finished starting Scheduler on host '" + str(host) + "'")
 
     def shutdown_scheduler(self, host):


### PR DESCRIPTION
- add timeout before checking scheduler is running on standby node

Issue:
- if active node completely goes down, the standby node accurate identifies the situation and attempts to start the scheduler on the standby node
- however, not enough time is allocated to allow for the restart to happen on standby node

Resolution:
- moved the time.sleep logic to the startup_scheduler method so it’s always applied